### PR TITLE
swap exact purchase for repo function

### DIFF
--- a/test/TestRepoTokenLinkedListContract.sol
+++ b/test/TestRepoTokenLinkedListContract.sol
@@ -99,7 +99,6 @@ contract TestRepoTokenLinkedListContract is RepoTokenLinkedListTestBase {
         listingContract.swapExactPurchaseForRepo(purchaseTokenAmount, address(repoToken1));
     }
 
-
     function testAdminFunctions() public {
         // blacklist
         assertEq(listingContract.repoTokenBlacklist(address(repoToken1)), false);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new purchasing method allowing users to specify the amount of purchase tokens instead of repo tokens.
	- Enhanced flexibility in purchasing repo tokens through the `swapExactPurchaseForRepo` function.

- **Tests**
	- Added a new test for the `swapExactPurchaseForRepo` function to ensure its functionality and correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->